### PR TITLE
Replace Set of  removed indexes with a Queue

### DIFF
--- a/HNSWIndex/GraphDataSnapshot.cs
+++ b/HNSWIndex/GraphDataSnapshot.cs
@@ -17,7 +17,7 @@ namespace HNSWIndex
         internal ConcurrentDictionary<int, TLabel>? Items { get; set; }
 
         [ProtoMember(3)]
-        internal HashSet<int>? RemovedIndexes { get; set; }
+        internal Queue<int>? RemovedIndexes { get; set; }
 
         [ProtoMember(4)]
         internal int EntryPointId = -1;

--- a/HNSWIndex/HNSWInfo.cs
+++ b/HNSWIndex/HNSWInfo.cs
@@ -4,7 +4,7 @@
     {
         public List<LayerInfo> Layers;
 
-        internal HNSWInfo(List<Node> nodes, HashSet<int> removedNodes, int maxLayer)
+        internal HNSWInfo(List<Node> nodes, Queue<int> removedNodes, int maxLayer)
         {
             Layers = new List<LayerInfo>(maxLayer + 1);
             for (int layer = 0; layer <= maxLayer; layer++)


### PR DESCRIPTION
Replace container for used indexes.
Queue allows predictable index reusage, requires less memory, and generally is a better fit.